### PR TITLE
Fix unique constraint of news table

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -66,4 +66,6 @@ CREATE TABLE IF NOT EXISTS comments (
 );
 
 
-ALTER TABLE `users` ADD UNIQUE user_unique_username (`userName`)
+ALTER TABLE `users` ADD UNIQUE user_unique_username (`userName`);
+DROP INDEX  unique_author_title ON news;
+ALTER TABLE `news` ADD UNIQUE news_unique_title (`title`);


### PR DESCRIPTION
### Why
The News API could return news with `null` in author column
This causes to store the duplicated records in news table
This PR fixes that problem

### How
Replace `unique_author_title` index with `unique_title` index